### PR TITLE
[testing only] Enable building leapp-repository for specific chroots only

### DIFF
--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -32,5 +32,4 @@ jobs:
           EOF
 
           pip install copr-cli
-          make copr_build
-
+          COPR_CONFIG=$COPR_CONFIG COPR_CHROOT=$COPR_CHROOT make copr_build

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -37,8 +37,11 @@ jobs:
 
       - name: Trigger copr build
         id: copr_build
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
         run: |
-          cat << EOF > copr_fedora.conf
+          cat << EOF > $COPR_CONFIG
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
           username = @oamg
@@ -48,7 +51,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CONFIG=$COPR_CONFIG COPR_CHROOT=$COPR_CHROOT make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"
@@ -99,8 +102,11 @@ jobs:
       - name: Trigger copr build for leapp
         id: copr_build_leapp
         if: ${{ steps.leapp_pr_regex_match.outputs.match != '' }}
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
         run: |
-          cat << EOF > copr_fedora.conf
+          cat << EOF > $COPR_CONFIG
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
           username = @oamg
@@ -110,7 +116,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.leapp_pr.outputs.leapp_pr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.leapp_pr.outputs.leapp_pr }} COPR_CONFIG=$COPR_CONFIG COPR_CHROOT=$COPR_CHROOT make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"


### PR DESCRIPTION
Instead of building for all project chroots use -r/--chroot
option to specify chroots.
Tmt-tests workflow and copr-build workflow will be passing proper
chroots now via COPR_CHROOT env var.
Also some refactoring has been done to the workflows to move all
magic constants to env section.

OAMG-6735